### PR TITLE
suwang ga / 220311 / 3문제

### DIFF
--- a/GSW/BOJ_2565_전깃줄_골드5.java
+++ b/GSW/BOJ_2565_전깃줄_골드5.java
@@ -1,0 +1,40 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Scanner;
+import java.util.StringTokenizer;
+
+public class BOJ_2565_전깃줄_골드5 {
+
+	public static void main(String[] args) throws IOException {
+		Scanner sc = new Scanner(System.in);
+		int N = sc.nextInt();
+		int [] arr1 = new int[N+1];
+		int [] arr2 = new int[N+1];
+		int max=0;
+		for(int i=1;i<=N;i++) {
+			arr1[i] = sc.nextInt();
+			arr2[i] = sc.nextInt();
+			max = Math.max(max, Math.max(arr1[i],arr2[i]));
+		}
+		int [] arr3 = new int[max+1];
+		for(int i=1;i<N+1;i++) {
+			arr3[arr2[i]] = arr1[i];
+		}
+		Arrays.sort(arr1);
+		int dp[][] = new int[arr1.length][max+1];
+		for(int i=1;i<arr1.length;i++) {
+			for(int j=1;j<=max;j++) {
+				if(arr1[i]==arr3[j]) {
+						dp[i][j]=dp[i-1][j-1]+1;
+						
+				}
+				else dp[i][j]=Math.max(dp[i][j-1], dp[i-1][j]);
+			}
+		}
+		System.out.println(N-dp[arr1.length-1][max]);
+	
+	}
+
+}

--- a/GSW/BOJ_9251_LCS_골드5.java
+++ b/GSW/BOJ_9251_LCS_골드5.java
@@ -1,0 +1,29 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Scanner;
+import java.util.StringTokenizer;
+
+public class BOJ_9251_LCS_골드5 {
+
+	public static void main(String[] args) throws IOException {
+		Scanner sc = new Scanner(System.in);
+		char [] arr1 = sc.nextLine().toCharArray();
+		char [] arr2 = sc.nextLine().toCharArray();
+		int max=1;
+		int dp[][] = new int[arr1.length+1][arr2.length+1];
+		for(int i=1;i<arr1.length+1;i++) {
+			for(int j=1;j<arr2.length+1;j++) {
+				if(arr1[i-1]==arr2[j-1]) {
+						dp[i][j]=dp[i-1][j-1]+1;
+						
+				}
+				else dp[i][j]=Math.max(dp[i][j-1], dp[i-1][j]);
+			}
+		}
+		System.out.println(dp[arr1.length][arr2.length]);
+	
+	}
+
+}

--- a/GSW/BOJ_가장긴증가하는부분수열_실버2.java
+++ b/GSW/BOJ_가장긴증가하는부분수열_실버2.java
@@ -1,0 +1,34 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Scanner;
+import java.util.StringTokenizer;
+
+public class BOJ_가장긴증가하는부분수열_실버2 {
+
+	public static void main(String[] args) throws IOException {
+		Scanner sc = new Scanner(System.in);
+		int N = sc.nextInt();
+		int [] arr = new int[N];
+		int [] dp = new int[N];
+		for(int i=0;i<N;i++) {
+			arr[i] = sc.nextInt();
+		}
+		
+		for(int i=0;i<N;i++) {
+			dp[i] =1;
+			for(int j=0;j<i;j++) {
+				if(arr[j]<arr[i]&&dp[i]<dp[j]+1) {
+					dp[i] = dp[j]+1;
+				}
+			}
+		}
+		int max = 0;
+		for(int i=0;i<N;i++) {
+			max=Math.max(max,dp[i]);
+		}
+		System.out.println(max);
+	}
+
+}


### PR DESCRIPTION
### 가장 긴 증가하는 수열
강의를 봐도 원리가 이해가 잘 되지 않아 좀 오래 걸렸습니다..


### LCS
옛날에 문자열 변경 알고리즘과 비슷하다는 느낌을 받아 2차원 배열을 이용해 풀었습니다. 좀 헤맸는데 그래도 저번 문제들보다 빨리 해결할 수 있었습니다.


### 전깃줄
LCS푼 다음 바로 풀어서 그런지 LCS와 같은 문제라는 느낌을 받았습니다. 

<인덱스를 1부터 사용하기 위해 모든 배열의 크기를 +1 해 사용했습니다.>
그래서 입력된 한쪽 전봇대의 번호와(arr1) 각각 연결된 다른쪽 전봇대의 번호(arr2)를 저장했습니다. 

입력된 번호중 가장 큰 번호를 길이로 하는 배열(arr3)를 하나 더 만들어서 arr2의 값을 인덱스로 하고 arr1의 값을 저장했습니다.  이후 arr1을 정렬해주었습니다.

이후 arr1과 arr3간 교차하지 않는 전깃줄의 최대 개수는 arr1과 arr3의 LCS와 같아져 그 다음에는 LCS코드를 그대로 이용했습니다. 
답은 처음 입력된 전깃줄 수에서 arr1과 arr3의 LCS를 빼주면 없애야 하는 전깃줄의 최소개수가 됩니다.

( 8 <1,8> <3,9> <2,2> <4,1> <6,4> <10,10> <9,7> <7,6>) 입력 데이터가 다음과 같을때 (백준 예제입력입니다.)
arr1 [ 1, 2, 3, 4, 6, 7, 9, 10 ]  원소 8개
arr2 [ 8, 9, 2, 1, 4, 10, 7, 6 ]  원소 8개
//arr1과 arr2의 최대값이 10이기때문에 크기가 10인 배열 선언
arr3[ 4, 2, 0, 6, 0, 7, 9, 1, 3, 10] 원소 10개

arr1과 arr3의 LCS [2,6,7,9,10]

------------------------------------------------------------------------------------------------
이번에는 관련된 문제를 쭉 풀어서 어떻게 풀어야할지 금방 떠올랐는데 전깃줄 같은 문제를 갑자기 만나면 너무 당황스러울거 같네요 그리고 dp문제는 뭔가 설명하기 너무 어려운거같아요..ㅠ